### PR TITLE
Fix bugs in command flags forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@semantic-release/github": "5.2.x",
     "@semantic-release/npm": "5.1.x",
     "@semantic-release/release-notes-generator": "7.1.x",
-    "@stoplight/scripts": "https://github.com/stoplightio/scripts.git#fix/do-not-provide-source-files",
     "@storybook/addon-actions": "4.0.4",
     "@storybook/addon-info": "4.0.4",
     "@storybook/addon-knobs": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "@semantic-release/github": "5.2.x",
     "@semantic-release/npm": "5.1.x",
     "@semantic-release/release-notes-generator": "7.1.x",
+    "@stoplight/scripts": "https://github.com/stoplightio/scripts.git#fix/do-not-provide-source-files",
     "@storybook/addon-actions": "4.0.4",
     "@storybook/addon-info": "4.0.4",
     "@storybook/addon-knobs": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "lint-staged": {
-    "src/*.ts": [
+    "*.ts": [
       "yarn lint.fix",
       "git add"
     ]

--- a/src/commands/__tests__/lint-command.ts
+++ b/src/commands/__tests__/lint-command.ts
@@ -22,10 +22,10 @@ describe('sl-scripts lint', () => {
   });
 
   // TODO
-  it.skip('should support passing in a path', async () => {
+  it('should support passing in a path', async () => {
     await LintCommand.run(['custom/**']);
     expect(shellCommands).toEqual([
-      '/mock/node_modules/.bin/tslint --format codeFrame --project /mock/node_modules/@stoplight/scripts/tsconfig.json "custom/**"',
+      '/mock/node_modules/.bin/tslint custom/** --format codeFrame --project /mock/node_modules/@stoplight/scripts/tsconfig.json',
     ]);
   });
 

--- a/src/commands/__tests__/lint-command.ts
+++ b/src/commands/__tests__/lint-command.ts
@@ -21,7 +21,6 @@ describe('sl-scripts lint', () => {
     ]);
   });
 
-  // TODO
   it('should support passing in a path', async () => {
     await LintCommand.run(['custom/**']);
     expect(shellCommands).toEqual([

--- a/src/commands/__tests__/lint-command.ts
+++ b/src/commands/__tests__/lint-command.ts
@@ -28,6 +28,14 @@ describe('sl-scripts lint', () => {
     ]);
   });
 
+  it('should support passing multiple file names', async () => {
+    await LintCommand.run(['f1.ts', 'f2.ts']);
+    expect(shellCommands).toEqual([
+      '/mock/node_modules/.bin/tslint f1.ts f2.ts --format codeFrame --project /mock/node_modules/@stoplight/scripts/tsconfig.json',
+    ]);
+  });
+
+
   it('should use user defined jest config file if present', async () => {
     jest.spyOn(fs, 'existsSync').mockImplementation(() => true);
     await LintCommand.run();

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -38,6 +38,7 @@ export default class BuildCommand extends Command {
           project: `--project ${getConfigFilePath('tsconfig.json')}`,
         },
         rawArgs: parsed.raw,
+        flags: Object.keys(BuildCommand.flags),
       })
     );
 

--- a/src/commands/build/tsdoc.ts
+++ b/src/commands/build/tsdoc.ts
@@ -38,7 +38,7 @@ export default class BuildTsdocCommand extends Command {
           excludeProtected: `--excludeProtected`,
         },
         rawArgs: parsed.raw,
-        flags: Object.keys(BuildTsdocCommand.flags)
+        flags: Object.keys(BuildTsdocCommand.flags),
       })} src`
     );
 

--- a/src/commands/build/tsdoc.ts
+++ b/src/commands/build/tsdoc.ts
@@ -38,6 +38,7 @@ export default class BuildTsdocCommand extends Command {
           excludeProtected: `--excludeProtected`,
         },
         rawArgs: parsed.raw,
+        flags: Object.keys(BuildTsdocCommand.flags)
       })} src`
     );
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -38,8 +38,6 @@ export default class LintCommand extends Command {
       rawArgs: parsed.raw,
     });
 
-    command += ' "src/**/*.ts"';
-
     if (parsed.flags.verbose) {
       this.log(`command: '${command}'`);
     }

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -32,7 +32,7 @@ export default class LintCommand extends Command {
       rawArgs: parsed.raw,
     });
 
-    if (!!!parsed.args['path'] || !!!path.parse(parsed.args['path']).dir) {
+    if (!parsed.args['path'] || !path.parse(parsed.args['path']).dir) {
       command += ' "src/**/*.ts"';
     }
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -11,7 +11,7 @@ export default class LintCommand extends Command {
 
   public static examples = [`$ sl-scripts lint`, `$ sl-scripts lint src/**/*`];
 
-  public static args = [{ name: 'path' }];
+  public static args = [];
 
   public static flags = {
     verbose: flagHelpers.boolean({
@@ -30,6 +30,7 @@ export default class LintCommand extends Command {
         config: `--config ${getConfigFilePath('tslint.json')}`,
       },
       rawArgs: parsed.raw,
+      flags: Object.keys(LintCommand.flags),
     });
 
     if (!parsed.args.path || !path.parse(parsed.args.path).dir) {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -20,7 +20,7 @@ export default class LintCommand extends Command {
   };
 
   public async run() {
-    const parsed = this.parse<{ verbose: boolean }, { path: string }>(LintCommand);
+    const parsed = this.parse(LintCommand);
 
     let command = buildCommand('tslint', {
       defaultArgs: {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,4 +1,5 @@
 import { Command, flags as flagHelpers } from '@oclif/command';
+import path = require('path');
 import * as shell from 'shelljs';
 
 import { buildCommand, getConfigFilePath } from '../utils';
@@ -10,14 +11,7 @@ export default class LintCommand extends Command {
 
   public static examples = [`$ sl-scripts lint`, `$ sl-scripts lint src/**/*`];
 
-  public static args = [
-    // TODO: support the path arg
-    // {
-    //   name: 'path',
-    //   description: 'a glob that describes the files to lint lint',
-    //   required: false,
-    // },
-  ];
+  public static args = [{ name: 'path' }];
 
   public static flags = {
     verbose: flagHelpers.boolean({
@@ -37,6 +31,10 @@ export default class LintCommand extends Command {
       },
       rawArgs: parsed.raw,
     });
+
+    if (!!!parsed.args['path'] || !!!path.parse(parsed.args['path']).dir) {
+      command += ' "src/**/*.ts"';
+    }
 
     if (parsed.flags.verbose) {
       this.log(`command: '${command}'`);

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -21,7 +21,7 @@ export default class LintCommand extends Command {
   };
 
   public async run() {
-    const parsed = this.parse(LintCommand);
+    const parsed = this.parse<{ verbose: boolean }, { path: string }>(LintCommand);
 
     let command = buildCommand('tslint', {
       defaultArgs: {
@@ -32,7 +32,7 @@ export default class LintCommand extends Command {
       rawArgs: parsed.raw,
     });
 
-    if (!parsed.args['path'] || !path.parse(parsed.args['path']).dir) {
+    if (!parsed.args.path || !path.parse(parsed.args.path).dir) {
       command += ' "src/**/*.ts"';
     }
 

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,5 +1,4 @@
 import { Command, flags as flagHelpers } from '@oclif/command';
-import path = require('path');
 import * as shell from 'shelljs';
 
 import { buildCommand, getConfigFilePath } from '../utils';
@@ -33,7 +32,7 @@ export default class LintCommand extends Command {
       flags: Object.keys(LintCommand.flags),
     });
 
-    if (!parsed.args.path || !path.parse(parsed.args.path).dir) {
+    if (parsed.argv.length === 0) {
       command += ' "src/**/*.ts"';
     }
 

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -39,6 +39,7 @@ export default class TestCommand extends Command {
         config: `--config=${getConfigFilePath('jest.config.js')}`,
       },
       rawArgs: parsed.raw,
+      flags: Object.keys(TestCommand.flags),
     });
 
     if (parsed.flags.verbose) {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -19,11 +19,6 @@ export default class TestCommand extends Command {
   ];
 
   public static flags = {
-    watch: flagHelpers.boolean({
-      char: 'w',
-      description: 'run tests in watch mode',
-      required: false,
-    }),
     verbose: flagHelpers.boolean({
       description: 'moar logs',
       required: false,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,12 +4,12 @@ import * as path from 'path';
 
 export const buildCommand = (
   baseCommand: string,
-  { defaultArgs = {}, rawArgs = [] }: { defaultArgs?: any; rawArgs?: ParsingToken[] } = {}
+  { defaultArgs = {}, rawArgs = [], flags = [] }: { defaultArgs?: any; rawArgs?: ParsingToken[]; flags?: string[] } = {}
 ) => {
   let command = path.resolve(process.cwd(), 'node_modules', '.bin', baseCommand);
 
   for (const arg of rawArgs) {
-    command += ` ${arg.input}`;
+    if (!flags.includes(arg.input.substring(2))) command += ` ${arg.input}`;
   }
 
   for (const arg in defaultArgs) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,61 +1154,6 @@
     into-stream "^4.0.0"
     lodash "^4.17.4"
 
-"@stoplight/scripts@https://github.com/stoplightio/scripts.git#fix/do-not-provide-source-files":
-  version "0.0.0"
-  resolved "https://github.com/stoplightio/scripts.git#cc538172e6dbdf79fe43a2d32f7ee0d64cd565f9"
-  dependencies:
-    "@babel/core" "7.1.x"
-    "@commitlint/cli" "7.2.x"
-    "@commitlint/config-conventional" "7.1.x"
-    "@oclif/command" "1.5.x"
-    "@oclif/config" "1.9.x"
-    "@oclif/plugin-help" "2.1.x"
-    "@semantic-release/commit-analyzer" "6.1.x"
-    "@semantic-release/git" "7.0.x"
-    "@semantic-release/github" "5.2.x"
-    "@semantic-release/npm" "5.1.x"
-    "@semantic-release/release-notes-generator" "7.1.x"
-    "@storybook/addon-actions" "4.0.4"
-    "@storybook/addon-info" "4.0.4"
-    "@storybook/addon-knobs" "^4.0.4"
-    "@storybook/addon-links" "4.0.4"
-    "@storybook/addon-options" "4.0.4"
-    "@storybook/addons" "4.0.4"
-    "@storybook/core" "4.0.4"
-    "@storybook/react" "4.0.4"
-    "@types/jest" "23.3.x"
-    "@types/node" "10.12.x"
-    "@types/storybook__addon-actions" "3.4.1"
-    "@types/storybook__addon-info" "3.4.2"
-    "@types/storybook__addon-knobs" "^3.4.1"
-    "@types/storybook__addon-links" "3.3.2"
-    "@types/storybook__addon-options" "3.2.2"
-    "@types/storybook__react" "4.0.0"
-    babel-loader "8.0.x"
-    cli-ux "4.9.x"
-    commitizen "3.0.x"
-    cz-conventional-changelog "2.1.x"
-    husky "1.1.x"
-    inquirer "6.2.x"
-    jest "23.6.x"
-    lint-staged "8.0.x"
-    lodash "4.x.x"
-    react-docgen-typescript-loader "3.0.x"
-    rimraf "2.6.x"
-    semantic-release "15.10.x"
-    shelljs "0.8.x"
-    ts-jest "23.10.x"
-    ts-loader "5.3.x"
-    tslib "1.9.x"
-    tslint-config-stoplight "1.2.x"
-    typedoc "0.13.x"
-    typescript-plugin-styled-components "1.0.x"
-  optionalDependencies:
-    react "16.x.x"
-    react-dom "16.x.x"
-    webpack "4.x.x"
-
 "@storybook/addon-actions@4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.4.tgz#134b83f287ab43ea59e55ce3b22126ebfd541f80"
@@ -4074,7 +4019,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6010,7 +5955,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7370,6 +7315,11 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7378,10 +7328,32 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
+
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
+lodash._getnative@*, lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -7462,6 +7434,11 @@ lodash.pick@4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
+
+lodash.restparam@*:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.snakecase@4.1.1:
   version "4.1.1"
@@ -9907,7 +9884,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1154,6 +1154,61 @@
     into-stream "^4.0.0"
     lodash "^4.17.4"
 
+"@stoplight/scripts@https://github.com/stoplightio/scripts.git#fix/do-not-provide-source-files":
+  version "0.0.0"
+  resolved "https://github.com/stoplightio/scripts.git#cc538172e6dbdf79fe43a2d32f7ee0d64cd565f9"
+  dependencies:
+    "@babel/core" "7.1.x"
+    "@commitlint/cli" "7.2.x"
+    "@commitlint/config-conventional" "7.1.x"
+    "@oclif/command" "1.5.x"
+    "@oclif/config" "1.9.x"
+    "@oclif/plugin-help" "2.1.x"
+    "@semantic-release/commit-analyzer" "6.1.x"
+    "@semantic-release/git" "7.0.x"
+    "@semantic-release/github" "5.2.x"
+    "@semantic-release/npm" "5.1.x"
+    "@semantic-release/release-notes-generator" "7.1.x"
+    "@storybook/addon-actions" "4.0.4"
+    "@storybook/addon-info" "4.0.4"
+    "@storybook/addon-knobs" "^4.0.4"
+    "@storybook/addon-links" "4.0.4"
+    "@storybook/addon-options" "4.0.4"
+    "@storybook/addons" "4.0.4"
+    "@storybook/core" "4.0.4"
+    "@storybook/react" "4.0.4"
+    "@types/jest" "23.3.x"
+    "@types/node" "10.12.x"
+    "@types/storybook__addon-actions" "3.4.1"
+    "@types/storybook__addon-info" "3.4.2"
+    "@types/storybook__addon-knobs" "^3.4.1"
+    "@types/storybook__addon-links" "3.3.2"
+    "@types/storybook__addon-options" "3.2.2"
+    "@types/storybook__react" "4.0.0"
+    babel-loader "8.0.x"
+    cli-ux "4.9.x"
+    commitizen "3.0.x"
+    cz-conventional-changelog "2.1.x"
+    husky "1.1.x"
+    inquirer "6.2.x"
+    jest "23.6.x"
+    lint-staged "8.0.x"
+    lodash "4.x.x"
+    react-docgen-typescript-loader "3.0.x"
+    rimraf "2.6.x"
+    semantic-release "15.10.x"
+    shelljs "0.8.x"
+    ts-jest "23.10.x"
+    ts-loader "5.3.x"
+    tslib "1.9.x"
+    tslint-config-stoplight "1.2.x"
+    typedoc "0.13.x"
+    typescript-plugin-styled-components "1.0.x"
+  optionalDependencies:
+    react "16.x.x"
+    react-dom "16.x.x"
+    webpack "4.x.x"
+
 "@storybook/addon-actions@4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@storybook/addon-actions/-/addon-actions-4.0.4.tgz#134b83f287ab43ea59e55ce3b22126ebfd541f80"
@@ -4019,7 +4074,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -5955,7 +6010,7 @@ import-local@^1.0.0:
     pkg-dir "^2.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -7315,11 +7370,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -7328,32 +7378,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -7434,11 +7462,6 @@ lodash.pick@4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
   integrity sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.snakecase@4.1.1:
   version "4.1.1"
@@ -9884,7 +9907,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
This PR will make sure that declared flags won't get forwarded to the underlying command as well make sure that it's possible to provide single and multi files to lint command — indispensable to make `lint-staged` work correctly 

Closes #5 
Closes #6