### PR TITLE
feat: allow ES2018/19 features in TypeScript files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "node",
     "target": "es6",
     "module": "esnext",
-    "lib": ["es2015", "es2016", "es2017", "dom"],
+    "lib": ["es2019", "dom"],
     "strict": true,
     "pretty": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
**This PR bumps the TS lib version from _ES2017_ to _ES2019_.**

### Rationale:

Library authors should be able to use the convenient features of ES18/19 (string trimming, array flatmap, etc.).

It is the responsibility of the end-user application to consider transpiling, polyfilling, etc.

### Support:
Chrome & Chromium edge - **full**
Firefox - **full** except for some advanced RegExp features
Edge (classic) - **little**, needs polyfilling if we support it
Safari - **almost full**
Node 10 - **some**
Node 12 - **full**

So we won't really need a lot of polyfills, either.

### Other options considered:

#### Bumping all the way to ES2020
Reasons against: 
1. There are not a lot of library-based features (namely `String.prototype.matchAll`, `BigInt`, `Promise.allSettled` and `globalThis`).
2. No real polyfill for `BigInt` AFAIK.
3. Pretty recent, not sure if we'd like to force everyone (every package user) to support ES2020 yet.

Reasons for:
1. The above-mentioned features
2. Bumping a target lib version can be a breaking change for the end-user applications (they suddenly need more polyfills), if we now declare that we use ES2020 we don't have to make another breaking change later if we are going to want ES2020.

#### Bumping the target version as well

In theory we could bump that too, because it is the responsibility of the application to transpile the syntax. I don't see what features we'd gain with this (maybe a smaller output), but we might still consider bumping the requirements, for reasons above.