### PR TITLE
fix: buildCommand behavior in a monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "commitizen": "4.0.3",
     "cz-conventional-changelog": "3.1.x",
     "esm": "^3.2.25",
+    "find-up": "^4.1.0",
     "husky": "4.2.3",
     "inquirer": "7.0.4",
     "lint-staged": "10.0.7",

--- a/src/commands/release/__tests__/index.ts
+++ b/src/commands/release/__tests__/index.ts
@@ -19,6 +19,7 @@ describe('sl-scripts release', () => {
 
   it('should use the semantic-release binary in node modules', async () => {
     await BuildCommand.run();
-    expect(shellCommands).toEqual([path.resolve(cwd(), 'node_modules', '.bin', 'semantic-release')]);
+    expect(shellCommands).toHaveLength(1);
+    expect(shellCommands[0]).toContain('semantic-release');
   });
 });

--- a/src/commands/release/__tests__/index.ts
+++ b/src/commands/release/__tests__/index.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import * as utils from '../../../utils';
 import BuildCommand from '../index';
 
+const origCwd = process.cwd();
 const cwd = () => path.resolve(__dirname, 'fixtures');
 
 describe('sl-scripts release', () => {
@@ -17,9 +18,8 @@ describe('sl-scripts release', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  it('should use the semantic-release binary in node modules', async () => {
+  it('should use the semantic-release in node_modules', async () => {
     await BuildCommand.run();
-    expect(shellCommands).toHaveLength(1);
-    expect(shellCommands[0]).toContain('semantic-release');
+    expect(shellCommands).toEqual([path.resolve(origCwd, 'node_modules', '.bin', 'semantic-release')]);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { ParsingToken } from '@oclif/parser/lib/parse';
 import { execSync } from 'child_process';
+import * as findUp from 'find-up';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -11,7 +12,9 @@ export const buildCommand = (
     flags = [],
   }: { defaultArgs?: any; rawArgs?: ParsingToken[]; flags?: string[] } = {},
 ) => {
-  let command = baseCommand;
+  // TODO: use matcher function to match baseCommand.cmd for Windows?
+  let command = findUp.sync(path.join('node_modules', '.bin', baseCommand), { cwd: process.cwd() });
+  if (!command) throw new Error(`Unable to locate node_modules/.bin binary for ${baseCommand}`);
 
   for (const arg of rawArgs) {
     if (!flags.includes(arg.input.substring(2))) command += ` ${arg.input}`;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -11,7 +11,7 @@ export const buildCommand = (
     flags = [],
   }: { defaultArgs?: any; rawArgs?: ParsingToken[]; flags?: string[] } = {},
 ) => {
-  let command = path.resolve(process.cwd(), 'node_modules', '.bin', baseCommand);
+  let command = baseCommand;
 
   for (const arg of rawArgs) {
     if (!flags.includes(arg.input.substring(2))) command += ` ${arg.input}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,7 +2274,7 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3602,7 +3602,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4913,11 +4913,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4926,32 +4921,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -5007,11 +4980,6 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"


### PR DESCRIPTION
Assuming a fixed `node_modules` path breaks within a monorepo powered by yarn workspaces.

![image](https://user-images.githubusercontent.com/543372/87316112-9e636f80-c525-11ea-9a67-9c07b4318b20.png)

(because the dep is hoisted up to `.../source/stoplight/elements/node_modules/.bin/`)

There is no point in doing the resolution ourselves anyway. We can allow the shell to do the resolution based on PATH, which will then work regardless of where the dependency is located exactly.