### PR TITLE
fix: bundle command now supports monorepos

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ const getConfigFile = name => {
     return filePath;
   }
 
-  return path.resolve(BASE_PATH, 'node_modules', '@stoplight', 'scripts', name);
+  return require.resolve(`@stoplight/scripts/${name}`);
 };
 
 const plugins = () =>


### PR DESCRIPTION
## Background

We're trying to use the `bundle` command from the latest `scripts` in `elements`.

Related https://github.com/stoplightio/elements/pull/1386

## Summary

Using `bundle` in a monorepo setup (or in any non-conventional `node_modules` structure) is failing because `getConfigFile` is making strong assumptions on where `@stoplight/scripts` is installed. @P0lip is there any reason for that? I've replaced it with a simple `require.resolve`, seems to now work in both monorepos and regular ones as well (tried with `elements` and `json-schema-viewer`).