### PR TITLE
Revert "chore: format rollup.config.js as ESM"

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,10 @@
-import commonjs from '@rollup/plugin-commonjs';
-import json from '@rollup/plugin-json';
-import fs from 'fs';
-import path from 'path';
-import { terser } from 'rollup-plugin-terser';
-import typescript from 'rollup-plugin-typescript2';
+'use strict';
+const typescript = require('rollup-plugin-typescript2');
+const { terser } = require('rollup-plugin-terser');
+const commonjs = require('@rollup/plugin-commonjs');
+const json = require('@rollup/plugin-json');
+const path = require('path');
+const fs = require('fs');
 
 const BASE_PATH = process.cwd();
 
@@ -32,7 +33,7 @@ const dependencies = [
 ];
 const external = module => dependencies.some(dep => module === dep || module.startsWith(`${dep}/`));
 
-export default [
+module.exports = [
   {
     input: path.resolve(BASE_PATH, 'src/index.ts'),
     output: {


### PR DESCRIPTION
Reverts stoplightio/scripts#85

Breaks node 12 as well :(