### PR TITLE
feat: enable custom packages encapsulation

### DIFF
--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -85,6 +85,7 @@ export default class BuildCommand extends Command {
       'dependenciesMeta',
       'pkg',
       'type',
+      'exports',
     ]);
 
     releasePkg.main = 'index.js';

--- a/src/commands/bundle/index.ts
+++ b/src/commands/bundle/index.ts
@@ -47,15 +47,23 @@ export default class BundleCommand extends BuildCommand {
   protected preparePackageJson() {
     const pkg = super.preparePackageJson();
 
+    const exports = {
+      require: './index.js',
+      import: './index.mjs',
+    };
+
     Object.assign(pkg, {
       type: 'commonjs',
       main: './index.js',
       // webpack v4 support
       module: './index.esm.js',
-      exports: {
-        require: './index.js',
-        import: './index.mjs',
-      },
+      exports:
+        'exports' in pkg && typeof pkg.exports === 'object'
+          ? {
+              ...pkg.exports,
+              '.': exports,
+            }
+          : exports,
     });
 
     return pkg;


### PR DESCRIPTION
Needed by https://github.com/stoplightio/elements/issues/1392

Having `exports` property set to:
```json
{
  "require": "./index.js",
  "import": "./index.mjs"
}
```
encapsulates exported packages preventing any other to be used. This PR allows setting custom packages by defining them in the original `package.json` file. 

This way using
```json
"exports": {
  "./styles.min.css": "./styles.min.css"
}
```


results in
```json
"exports": {
  "./styles.min.css": "./styles.min.css",
  ".": {
    "require": "./index.js",
    "import": "./index.mjs"
  }
}
```

