### PR TITLE
build: broken resolution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:lts
     steps:
       - checkout
       - run: yarn

--- a/test/test-build-on-repository.sh
+++ b/test/test-build-on-repository.sh
@@ -12,9 +12,8 @@ git clone git@github.com:stoplightio/$Repository.git
 
 cd $Repository
 
-npx json -I -f package.json -e "this.resolutions={
-\"@stoplight/scripts\": \"file:../project\",
-}"
+tmp=$(mktemp)
+jq '.resolutions."@stoplight/scripts" = "file:../project"' package.json > "$tmp" && mv "$tmp" package.json
 
 yarn
 yarn build


### PR DESCRIPTION
Currently we don't set resolution successfully, so we still run the test against the npm version of stoplight/scripts instead of the current. This fixes it.

<img width="1653" alt="image" src="https://user-images.githubusercontent.com/9273484/190267196-e817decf-553b-4f1f-b018-4863c179f53a.png">
